### PR TITLE
Share-specific CSS

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ It's possible to add a custom CSS file to the location `public/css/app-specific.
 
 If this file exists, it will be loaded automatically.
 
+It is also possible to add a custom CSS file solely for shared PDFs in multi-signature mode.  Add a custom CSS file to the location `public/css/share-specific.css` and if it exists, it will be loaded automatically.
 
 ### Custom retention period for shared PDF
 

--- a/templates/components/header.html.php
+++ b/templates/components/header.html.php
@@ -6,6 +6,9 @@
 <?php if (file_exists($ROOT."/public/css/app-specific.css")): ?>
 <link href="<?php echo $REVERSE_PROXY_URL; ?>/css/app-specific.css?<?php echo ($COMMIT) ? $COMMIT : filemtime($ROOT."/public/css/app-specific.css") ?>" rel="stylesheet">
 <?php endif; ?>
+<?php if (isset($hash) && !isset($noSharingMode) && file_exists($ROOT."/public/css/share-specific.css")): ?>
+<link href="<?php echo $REVERSE_PROXY_URL; ?>/css/share-specific.css?<?php echo ($COMMIT) ? $COMMIT : filemtime($ROOT."/public/css/share-specific.css") ?>" rel="stylesheet">
+<?php endif; ?>
 <link rel="icon" type="image/x-icon" href="<?php echo $REVERSE_PROXY_URL; ?>/favicon.ico">
 <link rel="icon" type="image/png" sizes="192x192" href="<?php echo $REVERSE_PROXY_URL; ?>/favicon.png" />
 <style>


### PR DESCRIPTION
This merges support for a custom CSS file specifically for the multi-signature mode, to allow for simplifying the "shared" view of a PDF to be signed.