### PR TITLE
Fix 404 error on shared PDF multi-signature page

### DIFF
--- a/templates/components/navtab.html.php
+++ b/templates/components/navtab.html.php
@@ -1,5 +1,5 @@
 <nav>
-    <a class="link-dark" href="<?php echo $REVERSE_PROXY_URL; ?>/"><img src="logo-small.svg" style="height: 40px; position: absolute;top: 5px;left: 8px;" />
+    <a class="link-dark" href="<?php echo $REVERSE_PROXY_URL; ?>/"><img src="<?php echo $REVERSE_PROXY_URL; ?>/logo-small.svg" style="height: 40px; position: absolute;top: 5px;left: 8px;" />
     <span class="d-none d-lg-inline" style="font-size: 15px; position: absolute;top: 10px;left: 54px;">Signature PDF</span>
     <span class="opacity-50 d-none d-lg-inline" style="font-size: 12px; position: absolute;top: 28px;left: 54px;"><?php echo _("Sign and manipulate PDFs freely") ?></span ></a>
 <?php if(!$disableOrganization): ?>


### PR DESCRIPTION
<img width="477" height="39" alt="image" src="https://github.com/user-attachments/assets/8a9537c9-0eaa-4569-881b-ce0501273f68" />

On multi-signature shared PDFs, there's a 404 error for the logo, which expects to be in the same path as the index file, and instead it's a subresource (the shared PDF's ID).  This merges specifying the absolute path, including the `REVERSE_PROXY_URL`, similar to how the various CSS and JS resources are references.